### PR TITLE
Retrieve cutouts

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,15 +3,22 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 RESULTS_DIR = "plots/results/"
+PYPSA_EARTH_DIR = "submodules/pypsa-earth/"
 
 
+configfile: "submodules/pypsa-earth/config.default.yaml"
+configfile: "submodules/pypsa-earth/configs/bundle_config.yaml"
 configfile: "configs/config.main.yaml"
 
 
 wildcard_constraints:
-    countries="[A-Z]{2}",
-    clusters="[0-9]+",
+    simpl="[a-zA-Z0-9]*|all",
+    clusters="[0-9]+(m|flex)?|all|min",
+    ll="(v|c)([0-9\.]+|opt|all)|all",
+    opts="[-+a-zA-Z0-9\.]*",
+    unc="[-+a-zA-Z0-9\.]*",
     planning_horizon="[0-9]{4}",
+    countries="[A-Z]{2}",
 
 
 localrules:
@@ -52,3 +59,14 @@ rule validate_all:
             + "generation_validation_detailed_{clusters}_{countries}_{planning_horizon}.png",
             **config["validation"],
         ),
+
+
+rule retrieve_cutouts:
+    params:
+        countries=config["countries"],
+    output:
+        cutouts=PYPSA_EARTH_DIR+"cutouts/cutout-2013-era5.nc"
+    resources:
+        mem_mb=16000,
+    script:
+        "scripts/retrieve_cutouts.py"

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -7,3 +7,15 @@ validation:
   clusters: [10]
   planning_horizon: [2020]
   opts: [Co2L-1H]
+
+
+custom_databundles:
+  bundle_cutouts_USA:
+    countries: [US]
+    category: cutouts
+    destination: "cutouts"
+    urls:
+      gdrive: https://drive.google.com/file/d/1Q8WpNct4I1JCjy4wRYtr5tfiR8RvTbrG/view?usp=sharing
+    output: [cutouts/cutout-2013-era5.nc]
+    disable_by_opt:
+      build_cutout: [all]

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -15,7 +15,7 @@ custom_databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/1Q8WpNct4I1JCjy4wRYtr5tfiR8RvTbrG/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1AhqWEwNgp2r8cqIugXJg7CxkQfbqw-Dh/view?usp=sharing
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]

--- a/scripts/retrieve_cutouts.py
+++ b/scripts/retrieve_cutouts.py
@@ -2,18 +2,16 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, PYPSA_EARTH_DIR
+import warnings
+from zipfile import ZipFile
+import re
+from google_drive_downloader import GoogleDriveDownloader as gdd
+from pathlib import Path
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
-from pathlib import Path
-from google_drive_downloader import GoogleDriveDownloader as gdd
-import re
-from zipfile import ZipFile
-import yaml
-import logging
-import warnings
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../")))
 warnings.filterwarnings("ignore")
-from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, PYPSA_EARTH_DIR
 
 
 logger = create_logger(__name__)
@@ -74,7 +72,7 @@ def download_and_unzip_gdrive(config, disable_progress=False):
         logger.info(f"Download resource '{resource}' from cloud '{url}'.")
 
         return True
-    
+
     except Exception as e:
         logger.error(f"Failed to download or extract the file: {str(e)}")
         return False
@@ -88,7 +86,8 @@ if __name__ == "__main__":
             countries=["US"]
         )
     # update config based on wildcards
-    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+    config = update_config_from_wildcards(
+        snakemake.config, snakemake.wildcards)
 
     # load cutouts configuration
     config_cutouts = config["custom_databundles"]["bundle_cutouts_USA"]

--- a/scripts/retrieve_cutouts.py
+++ b/scripts/retrieve_cutouts.py
@@ -61,9 +61,9 @@ def download_and_unzip_gdrive(config, disable_progress=False):
         with ZipFile(file_path, "r") as zipObj:
             bad_file = zipObj.testzip()
             if bad_file:
-                print(f"Corrupted file found: {bad_file}")
+                logger.info(f"Corrupted file found: {bad_file}")
             else:
-                print("No errors found in the zip file.")
+                logger.info("No errors found in the zip file.")
             # Extract all the contents of zip file in current directory
             zipObj.extractall(path=destination)
         # remove tempfile.zip

--- a/scripts/retrieve_cutouts.py
+++ b/scripts/retrieve_cutouts.py
@@ -2,16 +2,16 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, PYPSA_EARTH_DIR
-import warnings
-from zipfile import ZipFile
-import re
-from google_drive_downloader import GoogleDriveDownloader as gdd
-from pathlib import Path
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(__file__, "../../")))
+sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
+from pathlib import Path
+from google_drive_downloader import GoogleDriveDownloader as gdd
+import re
+from zipfile import ZipFile
+import warnings
 warnings.filterwarnings("ignore")
+from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, PYPSA_EARTH_DIR
 
 
 logger = create_logger(__name__)
@@ -72,7 +72,7 @@ def download_and_unzip_gdrive(config, disable_progress=False):
         logger.info(f"Download resource '{resource}' from cloud '{url}'.")
 
         return True
-
+    
     except Exception as e:
         logger.error(f"Failed to download or extract the file: {str(e)}")
         return False
@@ -86,8 +86,7 @@ if __name__ == "__main__":
             countries=["US"]
         )
     # update config based on wildcards
-    config = update_config_from_wildcards(
-        snakemake.config, snakemake.wildcards)
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     # load cutouts configuration
     config_cutouts = config["custom_databundles"]["bundle_cutouts_USA"]

--- a/scripts/retrieve_cutouts.py
+++ b/scripts/retrieve_cutouts.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
+from pathlib import Path
+from google_drive_downloader import GoogleDriveDownloader as gdd
+import re
+from zipfile import ZipFile
+import yaml
+import logging
+import warnings
+warnings.filterwarnings("ignore")
+from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, PYPSA_EARTH_DIR
+
+
+logger = create_logger(__name__)
+
+
+def download_and_unzip_gdrive(config, disable_progress=False):
+    """
+        Downloads and unzips USA cutouts to submodules/pypsa-earth/cutouts folder 
+    """
+    resource = config["category"]
+    file_path = os.path.join(PYPSA_EARTH_DIR, "tempfile.zip")
+    destination = os.path.join(PYPSA_EARTH_DIR, config["destination"])
+    url = config["urls"]["gdrive"]
+
+    # retrieve file_id from path
+    try:
+        # cut the part before the ending \view
+        partition_view = re.split(r"/view|\\view", str(url), 1)
+        if len(partition_view) < 2:
+            logger.error(
+                f'Resource {resource} cannot be downloaded: "\\view" not found in url {url}'
+            )
+            return False
+
+        # split url to get the file_id
+        code_split = re.split(r"\\|/", partition_view[0])
+
+        if len(code_split) < 2:
+            logger.error(
+                f'Resource {resource} cannot be downloaded: character "\\" not found in {partition_view[0]}'
+            )
+            return False
+
+        # get file id
+        file_id = code_split[-1]
+
+        # remove tempfile.zip if exists
+        Path(file_path).unlink(missing_ok=True)
+
+        # download file from google drive
+        gdd.download_file_from_google_drive(
+            file_id=file_id,
+            dest_path=file_path,
+            showsize=not disable_progress,
+            unzip=False,
+        )
+        with ZipFile(file_path, "r") as zipObj:
+            bad_file = zipObj.testzip()
+            if bad_file:
+                print(f"Corrupted file found: {bad_file}")
+            else:
+                print("No errors found in the zip file.")
+            # Extract all the contents of zip file in current directory
+            zipObj.extractall(path=destination)
+        # remove tempfile.zip
+        Path(file_path).unlink(missing_ok=True)
+
+        logger.info(f"Download resource '{resource}' from cloud '{url}'.")
+
+        return True
+    
+    except Exception as e:
+        logger.error(f"Failed to download or extract the file: {str(e)}")
+        return False
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "retrieve_cutouts",
+            configfile="configs/calibration/config.usa_PE.yaml",
+            countries=["US"]
+        )
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+    # load cutouts configuration
+    config_cutouts = config["custom_databundles"]["bundle_cutouts_USA"]
+
+    # download cutouts
+    downloaded = download_and_unzip_gdrive(config_cutouts)


### PR DESCRIPTION
Good day. This is a PR that adds a rule to retrieve US cutouts (20GB) from google drive and place into cutouts folder. This rule will be used in our full workflow to prepare all necessary data before/while running. Currently, it is possible to run command: `snakemake -j1 retrieve_cutouts` to retrieve US cutouts into right folder. Also we could use `--configfile` flag to specify another scenario-specific cutout in future (e.g. if we want also 2018 cutouts, it is just a thought).

I am thinking of adding a function to check if cutouts are already present, so it will not be re-downloaded again. It will help accidentally re-writing cutouts. So probably it will check the size of `cutouts-2013-era5.nc`, where it should match exactly (are almost exactly) the size real cutouts. 

Or we can leave it as it is. Because cutouts can be downloaded only once and we will just as instructions to retrieve data as a first step as a single rule (e.g. `retrieve_all_data`).