### PR TITLE
Use US-specific costs from oet/technology-data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "submodules/pypsa-earth"]
 	path = submodules/pypsa-earth
 	url = https://github.com/open-energy-transition/pypsa-earth.git
-
-[submodule "submodules/technology-data"]
-	path = submodules/technology-data
-	url = https://github.com/open-energy-transition/technology-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "submodules/pypsa-earth"]
 	path = submodules/pypsa-earth
 	url = https://github.com/open-energy-transition/pypsa-earth.git
+
+[submodule "submodules/technology-data"]
+	path = submodules/technology-data
+	url = https://github.com/open-energy-transition/technology-data.git

--- a/Snakefile
+++ b/Snakefile
@@ -9,7 +9,10 @@ import sys
 sys.path.append("submodules/pypsa-earth")
 sys.path.append("submodules/pypsa-earth/scripts")
 
+from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 from scripts._helper import BASE_PATH
+
+HTTP = HTTPRemoteProvider()
 
 RESULTS_DIR = "plots/results/"
 PYPSA_EARTH_DIR = "submodules/pypsa-earth/"
@@ -205,6 +208,15 @@ if config["countries"] == ["US"]:
             mem_mb=16000,
         script:
             "scripts/retrieve_cutouts.py"
+
+
+use rule retrieve_cost_data_flexible from pypsa_earth with:
+    input:
+        HTTP.remote(
+            f"raw.githubusercontent.com/open-energy-transition/technology-data/nrel_atb_usa_costs/outputs/US/costs"
+            + "_{planning_horizons}.csv",
+            keep_local=True,
+        ),
 
 
 rule test_modify_prenetwork:

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,10 @@
 
 Please list contributions, add reference to PRs if present.
 
+* Integrated **US-specific cost assumptions** from NREL ATB to workflow: [PR #14](https://github.com/open-energy-transition/efuels-supply-potentials/pull/14) and technology-data [PR #1](https://github.com/open-energy-transition/technology-data/pull/1)
+
+* Prepared **merged airports** dataset: [PR #16](https://github.com/open-energy-transition/efuels-supply-potentials/pull/16)
+
 * Analyzed statewise **passengers and fuel consumption data** for fuel demand disaggregation for airports: [PR #9](https://github.com/open-energy-transition/efuels-supply-potentials/pull/9) 
 
 * Facilitated **PyPSA-Earth sector run**: PyPSA-Earth [PR #1134](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1134), [PR #1143](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1143), [PR #1145](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1145), [PR #1165](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1165), [PR #1166](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1166)


### PR DESCRIPTION
Good day. This PR proposes to enable using US-specific costs data from `open-energy-transition/technology-data` repository, branch `nrel_atb_usa_costs`. Changes include importing `retrieve_cost_data_flexible` rule and changing input URL to read from custom technology-data repository.