### PR TITLE
update: include method to preprocess merged data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -186,7 +186,7 @@ rule process_airport_data:
         passengers_data="data/airport_data/T100_Domestic_Market_and_Segment_Data_-3591723781169319541.csv",
     output:
         statewise_output="plots/results/passengers_vs_consumption.csv",
-        merged_data="plots/results/merged_data.csv",
+        merged_data="plots/results/merged_airports.csv",
         consumption_per_passenger="plots/results/consumption_per_passenger.png",
         correlation_matrix="plots/results/correlation_matrix.png",
         comparision_consumption_passengers="plots/results/comparision_consumption_passengers.png",

--- a/Snakefile
+++ b/Snakefile
@@ -186,6 +186,7 @@ rule process_airport_data:
         passengers_data="data/airport_data/T100_Domestic_Market_and_Segment_Data_-3591723781169319541.csv",
     output:
         statewise_output="plots/results/passengers_vs_consumption.csv",
+        merged_data="plots/results/merged_data.csv",
         consumption_per_passenger="plots/results/consumption_per_passenger.png",
         correlation_matrix="plots/results/correlation_matrix.png",
         comparision_consumption_passengers="plots/results/comparision_consumption_passengers.png",


### PR DESCRIPTION
This PR includes method to generate merged data for airport and passenger data. It also computes `fraction` which will be used in `prepare_sector_network` for distribution of demand. 

Following the fact that consumption at each airport is directly proportional to the number of passenger, the `fraction` is computed based on this assumption. $\frac{\text{Number of passengers in each airport}}{\text{Total number of passengers}}$
