### PR TITLE
Update `retrieve_costs` rule and comment until costs PR is integrated

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -219,13 +219,13 @@ if config["countries"] == ["US"] and config["retrieve_from_gdrive"].get("cutouts
             "scripts/retrieve_cutouts.py"
 
 
-use rule retrieve_cost_data_flexible from pypsa_earth with:
-    input:
-        HTTP.remote(
-            f"raw.githubusercontent.com/open-energy-transition/technology-data/nrel_atb_usa_costs/outputs/US/costs"
-            + "_{planning_horizons}.csv",
-            keep_local=True,
-        ),
+# use rule retrieve_cost_data from pypsa_earth with:
+#     input:
+#         HTTP.remote(
+#             f"raw.githubusercontent.com/open-energy-transition/technology-data/nrel_atb_usa_costs/outputs/US/costs"
+#             + "_{year}.csv",
+#             keep_local=True,
+#         ),
 
 
 # retrieving precomputed osm/raw data and bypassing download_osm_data rule

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -72,5 +72,5 @@ custom_databundles:
     category: resources_renewable_profiles
     destination: "resources"
     urls:
-      alternative_clustering: https://drive.google.com/file/d/1gkJ85L5jzH_Xxhjbr4fDBOVZeyFl-R-v/view?usp=sharing
+      alternative_clustering: https://drive.google.com/file/d/1Bt8NVxhe2-nrw2ZTg35sgUIQ-R8A57DN/view?usp=sharing
       voronoi_clustering: https://drive.google.com/file/d/1znCjfy3XYQrSiFoiB7PE95j__qnvo8Zt/view?usp=sharing


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to fix retrieval of costs file as `retrieve_cost_data_flexible` rule was removed from pypsa-earth rules. Also the rule is commented to prevent using US costs, as it needs change of the functions in pypsa-earth. It is done until costs PR is integrated to PyPSA-Earth.

## Changes
- [x] Custom costs is now retrieved with `retrieve_cost_data` rule
- [x] The rule is commented to prevent using US costs, because it requires selection of cost scenario and financial case within the code.