### PR TITLE
Separate e-kerosene and add saf mandate

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ snakemake -call statewise_validate_all --configfile configs/calibration/config.b
 |`modify_aviation_demand` |Any base or scenario config file         |Switches aviation demand in energy_total to custom demand|
 |`preprocess_demand_data` |Any base or scenario config file         |Preprocess utlities demand data into geojson|
 |`build_demand_profiles_from_eia` |Any base or scenario config file         |Build custom demand data from eia and bypass build_demand_profiles|
+|`set_saf_mandate`        |Any base or scenario config file         |Adds e-kerosene buses to enable split of aviation demand and sets SAF mandate if enabled| 
 
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -431,8 +431,10 @@ if config["demand_distribution"]["enable"]:
     ruleorder: build_demand_profiles_from_eia > build_demand_profiles
       
 
-if config["saf_mandate"]["enable"]:
+if config["saf_mandate"]["ekerosene_split"]:
     rule add_saf_mandate:
+        params:
+            blending_rate=config["saf_mandate"]["blending_rate"]
         input:
             network=PYPSA_EARTH_DIR + "results/"
             + SECDIR

--- a/Snakefile
+++ b/Snakefile
@@ -431,6 +431,28 @@ if config["demand_distribution"]["enable"]:
     ruleorder: build_demand_profiles_from_eia > build_demand_profiles
       
 
+if config["saf_mandate"]["enable"]:
+    rule add_saf_mandate:
+        input:
+            network=PYPSA_EARTH_DIR + "results/"
+            + SECDIR
+            + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc",
+        output:
+            modified_network=PYPSA_EARTH_DIR + "results/"
+            + SECDIR
+            + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_saf.nc",
+        script:
+            "scripts/add_saf_mandate.py"
+
+
+    use rule add_export from pypsa_earth with:
+        input:
+            **{k: v for k, v in rules.add_export.input.items() if k != "network"},
+            network=PYPSA_EARTH_DIR + "results/"
+            + SECDIR
+            + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_saf.nc",
+
+
 rule test_modify_prenetwork:
     input:
         prenetwork=PYPSA_EARTH_DIR + "networks/" + RDIR + "elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -432,7 +432,7 @@ if config["demand_distribution"]["enable"]:
       
 
 if config["saf_mandate"]["ekerosene_split"]:
-    rule add_saf_mandate:
+    rule set_saf_mandate:
         params:
             blending_rate=config["saf_mandate"]["blending_rate"]
         input:
@@ -444,7 +444,7 @@ if config["saf_mandate"]["ekerosene_split"]:
             + SECDIR
             + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_saf.nc",
         script:
-            "scripts/add_saf_mandate.py"
+            "scripts/set_saf_mandate.py"
 
 
     use rule add_export from pypsa_earth with:

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -23,7 +23,7 @@ aviation_demand_scenario:
 
 saf_mandate:
   ekerosene_split: true # separate e-kerosene as separate bus
-  enable_mandate: true # enable SAF mandate
+  enable_mandate: false # enable SAF mandate
   blending_rate: 0.05 # blending rate
 
 demand_distribution:

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -21,6 +21,11 @@ aviation_demand_scenario:
   year: 2023
   scenario: central # low, central or high
 
+saf_mandate:
+  ekerosene_split: true # separate e-kerosene as separate bus
+  enable_mandate: true # enable SAF mandate
+  blending_rate: 0.05 # blending rate
+
 demand_distribution:
   enable: true
   base_demand_year: 2023

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,8 @@
 
 Please list contributions, add reference to PRs if present.
 
+* Added functionality to separate **e-kerosene** demand and set **SAF mandate** by choosing blending rate: [PR #37](https://github.com/open-energy-transition/efuels-supply-potentials/pull/37) 
+
 * Integrated **generate aviation scenario** and **rescale fraction in airports dataset by state demand** into the workflow: [PR #35](https://github.com/open-energy-transition/efuels-supply-potentials/pull/35)
 
 * Integrated **demand redistribution** based on utility and balancing authority level demand [PR #34](https://github.com/open-energy-transition/efuels-supply-potentials/pull/34)

--- a/scripts/add_saf_mandate.py
+++ b/scripts/add_saf_mandate.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
+import pandas as pd
+import numpy as np
+from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, \
+                            configure_logging
+
+logger = create_logger(__name__)
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "add_saf_mandate",
+            configfile="configs/calibration/config.base.yaml",
+            simpl="",
+            ll="copt",
+            clusters=10,
+            opts="Co2L-24H",
+            sopts="24H",
+            planning_horizons=2020,
+            discountrate="0.071",
+            demand="AB",
+        )
+
+    configure_logging(snakemake)
+
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+

--- a/scripts/add_saf_mandate.py
+++ b/scripts/add_saf_mandate.py
@@ -8,9 +8,39 @@ sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
 import pandas as pd
 import numpy as np
 from scripts._helper import mock_snakemake, update_config_from_wildcards, create_logger, \
-                            configure_logging
+                            configure_logging, load_network
 
 logger = create_logger(__name__)
+
+
+def add_ekerosene_buses(n):
+    """
+        Adds e-kerosene buses and stores
+    """
+    # get oil bus names
+    oil_buses = n.buses.query("carrier in 'oil'")
+
+    # add e-kerosene bus
+    ekerosene_buses = [x.replace("oil", "e-kerosene") for x in oil_buses.index]
+    n.madd(
+        "Bus",
+        ekerosene_buses,
+        location=oil_buses.location,
+        carrier="e-kerosene",
+    )
+
+    # add e-kerosene carrier
+    n.add("Carrier", "e-kerosene", co2_emissions=n.carriers.loc["oil", "co2_emissions"])
+
+    # add e-kerosene stores
+    n.madd(
+        "Store",
+        [ekerosene_bus + " Store" for ekerosene_bus in ekerosene_buses],
+        bus=ekerosene_buses,
+        e_nom_extendable=True,
+        e_cyclic=True,
+        carrier="e-kerosene",
+    )
 
 
 if __name__ == "__main__":
@@ -32,4 +62,10 @@ if __name__ == "__main__":
 
     # update config based on wildcards
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+    # load the network
+    n = load_network(snakemake.input.network)
+
+    # add e-kerosene buses with store
+    add_ekerosene_buses(n)
 

--- a/scripts/set_saf_mandate.py
+++ b/scripts/set_saf_mandate.py
@@ -15,7 +15,7 @@ logger = create_logger(__name__)
 
 def add_ekerosene_buses(n):
     """
-        Adds e-kerosene buses and stores
+        Adds e-kerosene buses and stores, and adds links between e-kerosene and oil bus
     """
     # get oil bus names
     oil_buses = n.buses.query("carrier in 'oil'")
@@ -42,6 +42,17 @@ def add_ekerosene_buses(n):
         carrier="e-kerosene",
     )
     logger.info("Added E-kerosene buses, carrier, and stores")
+
+    # add links between E-kerosene and Oil buses so excess synthetic oil can be used
+    n.madd(
+        "Link",
+        [x + "-to-oil" for x in ekerosene_buses],
+        bus0=ekerosene_buses,
+        bus1=oil_buses.index,
+        carrier="e-kerosene-to-oil",
+        p_nom_extendable=True,
+        efficiency=1.0,
+    )
 
 
 def reroute_FT_output(n):
@@ -101,7 +112,7 @@ if __name__ == "__main__":
     # load the network
     n = load_network(snakemake.input.network)
 
-    # add e-kerosene buses with store
+    # add e-kerosene buses with store, and connect e-kerosene and oil buses
     add_ekerosene_buses(n)
 
     # reroute FT from oil buses to e-kerosene buses

--- a/scripts/set_saf_mandate.py
+++ b/scripts/set_saf_mandate.py
@@ -81,7 +81,7 @@ def redistribute_aviation_demand(n, rate):
 if __name__ == "__main__":
     if "snakemake" not in globals():
         snakemake = mock_snakemake(
-            "add_saf_mandate",
+            "set_saf_mandate",
             configfile="configs/calibration/config.base.yaml",
             simpl="",
             ll="copt",

--- a/scripts/set_saf_mandate.py
+++ b/scripts/set_saf_mandate.py
@@ -110,3 +110,6 @@ if __name__ == "__main__":
     # split aviation demand to e-kerosene to kerosene for aviation based on blending rate
     if config["saf_mandate"]["enable_mandate"]:
         redistribute_aviation_demand(n, rate=snakemake.params.blending_rate)
+
+    # save the modified network
+    n.export_to_netcdf(snakemake.output.modified_network)

--- a/scripts/set_saf_mandate.py
+++ b/scripts/set_saf_mandate.py
@@ -53,6 +53,7 @@ def add_ekerosene_buses(n):
         p_nom_extendable=True,
         efficiency=1.0,
     )
+    logger.info("Added links between E-kerosene and Oil buses")
 
 
 def reroute_FT_output(n):


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to reroute Fischer-Tropsch (FT) output to separate e-kerosene bus and implement SAF mandate.

## Changes
- [x] Create separate E-kerosene bus and stores 
- [x] Route FT output to it and connect E-kerosene to Oil buses with links  
- [x] Separate aviation demand based on blending rate