### PR TITLE
uncomment rule retrieve_cost_data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -231,7 +231,7 @@ if config["countries"] == ["US"] and config["retrieve_from_gdrive"].get("cutouts
 
 
 # TODO: revise retrieve cost data
-# use rule retrieve_cost_data from pypsa_earth with:
+use rule retrieve_cost_data from pypsa_earth with:
     input:
         HTTP.remote(
             f"raw.githubusercontent.com/open-energy-transition/technology-data/master/outputs/US/costs"


### PR DESCRIPTION
## Changes proposed in this Pull Request
I noticed a small error in the Snakefile in correspondence to `use rule retrieve_cost_data from pypsa-earth`. One line was mistakenly commented.