### PR TITLE
Add biogenic co2 split and clean H2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -502,6 +502,7 @@ if config["custom_industry"]["enable"]:
             add_steel=config["custom_industry"]["steel"],
             add_cement=config["custom_industry"]["cement"],
             ccs_retrofit=config["custom_industry"]["CCS_retrofit"],
+            biogenic_co2=config["custom_industry"]["biogenic_CO2"],
         input:
             industrial_energy_demand_per_node=PYPSA_EARTH_DIR + "resources/"
             + SECDIR

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -48,6 +48,7 @@ custom_industry:
   CCS_retrofit: [ethanol, ammonia, steel, cement]
   production_flexibility: []
   H2_DRI: false
+  biogenic_CO2: false
 
 custom_databundles:
   bundle_cutouts_USA:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to add option to split biogenic CO2 out of all co2 stored using config parameter. In addition, it aims to add option to make sure that input of Fischer-Tropsch is clean H2 from electrolysis, not just regular one.

## Changes
- [ ] Add option to split biogenic CO2 and reroute `ethanol from starch CC` and `Fischer-Tropsch` to use `biogenic co2 stored`
- [ ] Add option to `Fischer-Tropsch` to use clean H2 from electrolysis.