### PR TITLE
Myopic fix

### DIFF
--- a/configs/scenarios/config.myopic.yaml
+++ b/configs/scenarios/config.myopic.yaml
@@ -36,7 +36,7 @@ saf_mandate:
   ekerosene_split: true # separate e-kerosene as separate bus
   non_spatial_ekerosene: true # connects all e-kerosene buses with a single E-kerosene-main bus to model 0 cost of transport and store
   enable_mandate: true # enable SAF mandate
-  blending_rate: 0.007 # blending rate, 0.003 (EU -) 0.007 (EU) 0.012 (EU +)
+  saf_scenario: EU # EU (default), EU+, EU-
 
 demand_projection:
   planning_horizon: 2030 # only needed for power model, sector model takes demand from UN data using planning_horizon


### PR DESCRIPTION
## Changes proposed in this Pull Request
@yerbol-akhmetov @GbotemiB here are the changes needed in the submodule to properly run myopic optimization + a small fix to the new `config.myopic.yaml` to restore `saf_mandate` instead of hard-coded `blending rate`

## Changes
- [x] Update submodule head
- [x] Restore `saf_mandate` instead of hard-coded `blending rate` in `config.myopic.yaml` 