### PR TITLE
adjust prepare_costs in custom scripts

### DIFF
--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -15,6 +15,10 @@ retrieve_from_gdrive:
   base_network: true # if true, bypasses base_network rule
   renewable_profiles: true # if true, bypasses build_renewable_profiles rule
 
+costs:
+  output_currency: "USD"
+  default_USD_to_EUR: 0.7532 # previously USD2013_to_EUR2013; should be sufficient as current data from 'technology-data` are either in EUR or USD; [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
+
 # defining the aviation demand scenario
 aviation_demand_scenario:
   country: US

--- a/scripts/add_custom_brownfield.py
+++ b/scripts/add_custom_brownfield.py
@@ -105,9 +105,10 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.generators.sum() / 8760.0
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs["USD2013_to_EUR2013"],
+        snakemake.params.costs["output_currency"],
         snakemake.params.costs["fill_values"],
         Nyears,
+        snakemake.params.costs["default_USD_to_EUR"],
     )
 
     # set lifetime for nuclear, geothermal, and ror generators manually to non-infinity values

--- a/scripts/add_custom_existing_baseyear.py
+++ b/scripts/add_custom_existing_baseyear.py
@@ -417,9 +417,10 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.generators.sum() / 8760.0
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs["USD2013_to_EUR2013"],
+        snakemake.params.costs["output_currency"],
         snakemake.params.costs["fill_values"],
         Nyears,
+        snakemake.params.costs["default_USD_to_EUR"],
     )
 
     # set lifetime for nuclear, geothermal, and ror generators manually to non-infinity values

--- a/scripts/add_custom_industry.py
+++ b/scripts/add_custom_industry.py
@@ -833,9 +833,10 @@ if __name__ == "__main__":
     # Prepare the costs dataframe
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs["USD2013_to_EUR2013"],
+        snakemake.params.costs["output_currency"],
         snakemake.params.costs["fill_values"],
         Nyears,
+        snakemake.params.costs["default_USD_to_EUR"],
     )
 
     # add ammonia industry


### PR DESCRIPTION
## Changes proposed in this Pull Request
@yerbol-akhmetov @GbotemiB this PR performs small changes to the custom files where `prepare_costs` is used and sets the default currency to USD. Also requires the submodule to be fetch changes in this [PR](https://github.com/open-energy-transition/pypsa-earth/pull/50) to work.

## Changes
- [ ] 
- [ ] 
- [ ] 