### PR TITLE
Update submodule head to Cherry-pick Add US cost configurations and split scenarios per technology group

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Please review [a short tutorial](https://www.atlassian.com/git/tutorials/cherry-
 2. [PR #38](https://github.com/open-energy-transition/pypsa-earth/pull/38): Enable correct functioning of myopic optimization.
 3. [PR #40](https://github.com/open-energy-transition/pypsa-earth/pull/40): Adjusts calculation of `no_years` to properly run 2023 scenario.
 4. [PR #50](https://github.com/open-energy-transition/pypsa-earth/pull/50): Introduce Universal Currency Conversion to use USD as reference currency.
+5. [PR #51](https://github.com/open-energy-transition/pypsa-earth/pull/51): Add US cost configurations and split scenarios per technology group.
 
 ## 5. Validation
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Cherry-pick changes in https://github.com/open-energy-transition/pypsa-earth/pull/51

## Changes
- [ ] 
- [ ] 
- [ ] 