### PR TITLE
Fix data center planning horizon for base scenario

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,7 +8,7 @@
 
 Please list contributions, add reference to PRs if present.
 
-* Add **data center loads for sector model** [PR #81](https://github.com/open-energy-transition/efuels-supply-potentials/pull/81)
+* Add **data center loads for sector model** [PR #81](https://github.com/open-energy-transition/efuels-supply-potentials/pull/81) and [PR #84](https://github.com/open-energy-transition/efuels-supply-potentials/pull/84)
 
 * Prepare config files to define scenarios and review electrolyzer carriers [PR #76](https://github.com/open-energy-transition/efuels-supply-potentials/pull/76)
 

--- a/scripts/add_custom_industry.py
+++ b/scripts/add_custom_industry.py
@@ -864,7 +864,7 @@ def add_data_centers_load(n):
         Adds data centers loads based on state-wise data
     """
     # data center demand year
-    demand_horizon = 2023 if snakemake.wildcards.planning_horizons == 2020 else snakemake.wildcards.planning_horizons
+    demand_horizon = "2023" if snakemake.wildcards.planning_horizons == "2020" else snakemake.wildcards.planning_horizons
 
     # read data center loads data for given horizon
     demand_data_centers = read_data_center_profiles(demand_horizon, snakemake.params.data_center_profiles)
@@ -901,7 +901,7 @@ if __name__ == "__main__":
             clusters=10,
             opts="Co2L-24H",
             sopts="24H",
-            planning_horizons=2020,
+            planning_horizons="2020",
             discountrate="0.071",
             demand="AB",
         )


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR fixes the problem with planning horizon for base scenario. The problem was that `snakemake.wildcards.planning_horizons` is string not, integer. It could be easily prevented if mocksnakemake had planning_horizon as string. The PR fixes both.