### PR TITLE
updates to base year

### DIFF
--- a/configs/calibration/config.base.yaml
+++ b/configs/calibration/config.base.yaml
@@ -62,7 +62,7 @@ costs:
   marginal_cost:
     hydro: -6.00 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
     ror: -6.00 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
-    nuclear: 9.87 # USD/MWh - 45 U (nuclear original marginal cost - 10.00 USD/MWh)
+    nuclear: 9.87 # USD/MWh - 45 U (nuclear original marginal cost - 15.00 USD/MWh)
 
 policy_config:
   hydrogen:

--- a/configs/calibration/config.base.yaml
+++ b/configs/calibration/config.base.yaml
@@ -34,14 +34,14 @@ policies:
   country: [] # "CES"
 
 electricity:
-  co2limit: 1.4728e+9 # 0.8 * 1.841e+9
+  co2limit: 4.35e+9 #for calibration purposes
   co2base: 226.86e+6 #base_from_2020 Locations of the 250 MMmt of CO2 emissions from the WECC 2021.
 
   extendable_carriers:
     Generator: []
     Store: [battery, H2]
 
-  powerplants_filter: DateOut >= 2023 and DateIn < 2023
+  powerplants_filter: DateIn < 2023
   custom_powerplants: "replace" #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, geothermal, biomass]
@@ -57,6 +57,12 @@ renewable:
 
 costs:
   year: 2020
+  efficiency:
+      CCGT: 0.50
+  marginal_cost:
+    hydro: -6.00 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
+    ror: -6.00 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
+    nuclear: 9.87 # USD/MWh - 45 U (nuclear original marginal cost - 10.00 USD/MWh)
 
 policy_config:
   hydrogen:

--- a/configs/calibration/config.base.yaml
+++ b/configs/calibration/config.base.yaml
@@ -107,7 +107,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -29,10 +29,6 @@ costs:
   financial_case: "market" # only used if `country_specific_data: "US"`; can be "market" or "r&d"
   discountrate: [0.071] #, 0.086, 0.111]
   marginal_cost:
-    solar: -27.50 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
-    onwind: -27.50 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
-    # hydro: -6.00 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
-    biomass: -27.50 # USD/MWh - 45 Y (Source: https://atb.nrel.gov/electricity/2024/financial_cases_&_methods)
     ethanol carbon capture retrofit: -60.00 # USD/t_CO2 - 45 Q (utilization)
     ammonia carbon capture retrofit: -60.00 # USD/t_CO2 - 45 Q (utilization)
     cement carbon capture retrofit: -60.00 # USD/t_CO2 - 45 Q (utilization)
@@ -61,7 +57,7 @@ demand_distribution:
 demand_projection:
   planning_horizon: 2023
   scenario: "Medium"
-  data_centers_load: true
+  data_centers_load: false
 
 state_policy: "on" # "off", "on" manage application of renewable/clean energy policies at State- or country-level
 

--- a/configs/scenarios/config.scenario.01.yaml
+++ b/configs/scenarios/config.scenario.01.yaml
@@ -149,7 +149,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.02.yaml
+++ b/configs/scenarios/config.scenario.02.yaml
@@ -34,14 +34,14 @@ foresight: myopic
 scenario:
   simpl: ['']
   ll: ['copt']
-  clusters: [100]
-  opts: [3H]
+  clusters: [10]
+  opts: [24H]
   planning_horizons:
   - 2030
   - 2035
   - 2040
   sopts:
-  - "3H"
+  - "24H"
 
 aviation_demand_scenario:
   country: US
@@ -149,7 +149,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.03.yaml
+++ b/configs/scenarios/config.scenario.03.yaml
@@ -149,7 +149,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.04.yaml
+++ b/configs/scenarios/config.scenario.04.yaml
@@ -149,7 +149,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.05.yaml
+++ b/configs/scenarios/config.scenario.05.yaml
@@ -153,7 +153,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.06.yaml
+++ b/configs/scenarios/config.scenario.06.yaml
@@ -152,7 +152,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.07.yaml
+++ b/configs/scenarios/config.scenario.07.yaml
@@ -153,7 +153,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.08.yaml
+++ b/configs/scenarios/config.scenario.08.yaml
@@ -153,7 +153,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.09.yaml
+++ b/configs/scenarios/config.scenario.09.yaml
@@ -153,7 +153,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/configs/scenarios/config.scenario.10.yaml
+++ b/configs/scenarios/config.scenario.10.yaml
@@ -153,7 +153,8 @@ solving:
       threads: 8
       method: 2 # barrier
       crossover: 0
-      BarConvTol: 1.e-5
+      BarConvTol: 1.e-4
+      BarHomogenous: 1
 
 plotting:
   tech_colors:

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,8 @@
 
 Please list contributions, add reference to PRs if present.
 
+* **Base year**: Remove filtering for plants with DateOut >= 2023, remove PTC to existing wind, solar and biomass plants, add PTC for existing hydro and nuclear power plants, remove data center load [PR #85](https://github.com/open-energy-transition/efuels-supply-potentials/pull/85)
+
 * Add **data center loads for sector model** [PR #81](https://github.com/open-energy-transition/efuels-supply-potentials/pull/81) and [PR #84](https://github.com/open-energy-transition/efuels-supply-potentials/pull/84)
 
 * Prepare config files to define scenarios and review electrolyzer carriers [PR #76](https://github.com/open-energy-transition/efuels-supply-potentials/pull/76)

--- a/scripts/add_custom_industry.py
+++ b/scripts/add_custom_industry.py
@@ -686,6 +686,7 @@ def split_biogenic_CO2(n):
         biogenic_co2_stored_buses,
         e_nom_extendable=True,
         e_nom_max=np.inf,
+        e_cyclic=True,
         capital_cost=config["sector"]["co2_sequestration_cost"],
         carrier="biogenic co2 stored",
         bus=biogenic_co2_stored_buses,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR modifies base year modelling acting on:
- Remove filtering for plants with DateOut >= 2023 to ensure match of installed capacity (and generation) agains EIA/Ember
- Remove tax credits to existing wind, solar and biomass plants
- Add tax credits for existing hydro and nuclear power plants
- Remove data center load for base year to match NREL electricity use statistics