### PR TITLE
Add parallel routes for CO2 capture

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -510,6 +510,8 @@ if config["custom_industry"]["enable"]:
             data_centers=config["demand_projection"]["data_centers_load"],
             data_center_profiles="data/data_center_profiles/",
             geo_crs=config["crs"]["geo_crs"],
+            buffer_co2_stored=config["custom_industry"]["buffer_co2_stored"],
+            co2_storage_tanks=config["custom_industry"]["co2_storage_tanks"],
         input:
             industrial_energy_demand_per_node=PYPSA_EARTH_DIR + "resources/"
             + SECDIR

--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -73,6 +73,8 @@ custom_industry:
   biogenic_co2: false # define output of ethanol from starch CC as biogenic CO2 to be used in Fischer-Tropsch
   grid_H2: true # mark output of electrolysis as grid H2 (which can be used in Fischer-Tropsch)
   other_electricity: true # add other electricity as a consumption
+  buffer_co2_stored: true # switch output to buffer co2 stored
+  co2_storage_tanks: true # add CO2 storage tanks
 
 custom_databundles:
   bundle_cutouts_USA:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to add parallel routes for CO2 capture. The first route is storing to geological sequestration, named `co2 sequestered`. The second route is storing in `co2 storage tanks` for Fischer-Tropsch use. The excess co2 stored in tanks can be supplied to geological sequestration.

## Changes
- [ ] Add parallel routes of co2 storage
- [ ] Add diagram for routes
- [ ] 