### PR TITLE
Set OCGT and CCGT lifetime to 35

### DIFF
--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -28,6 +28,9 @@ costs:
     dac: "moderate"
   financial_case: "market" # only used if `country_specific_data: "US"`; can be "market" or "r&d"
   discountrate: [0.071] #, 0.086, 0.111]
+  lifetime:
+    CCGT: 35
+    OCGT: 35
 
 # defining the aviation demand scenario
 aviation_demand_scenario:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to set lifetime of OCGT and CCGT to 35 years to be consistent with `custom_powerplants.csv` provided, thanks to @danielelerede-oet for noticing it.

## Changes
- [x] Set lifetime of OCGT and CCGT to 35 years in config.