### PR TITLE
adjust base year co2 limit after fixing atmosphere typo

### DIFF
--- a/configs/calibration/config.base.yaml
+++ b/configs/calibration/config.base.yaml
@@ -35,7 +35,7 @@ policies:
   country: [] # "CES"
 
 electricity:
-  co2limit: 4.6e+9 #for calibration purposes
+  co2limit: 4.63e+9 #for calibration purposes
   co2base: 226.86e+6 #base_from_2020 Locations of the 250 MMmt of CO2 emissions from the WECC 2021.
   
   extendable_carriers:

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,8 @@
 
 Please list contributions, add reference to PRs if present.
 
+* Adjust *base year CO2 emissions limit* after changes in [PR #106] [PR #107](https://github.com/open-energy-transition/efuels-supply-potentials/pull/106)
+
 * Modify DAC inputs by **removing heat input** and **setting electricity-input to 1.4 MWh/t_CO2** [PR #105](https://github.com/open-energy-transition/efuels-supply-potentials/pull/105)
 
 * Set **OCGT and CCGT lifetime to 35 years** to be consistent with lifetime in `custom_powerplants.csv` [PR #103](https://github.com/open-energy-transition/efuels-supply-potentials/pull/103)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Hi @yerbol-akhmetov , 4.63 Gt is enough to get back to the previous situation with power sector CO2 emissions, LCOE and yearly generation shares after fixing the `atmosphere` typo.


<img width="923" height="511" alt="image" src="https://github.com/user-attachments/assets/22ff0aad-275f-4144-b307-b8ccc9d74764" />
<img width="681" height="586" alt="image" src="https://github.com/user-attachments/assets/c3d2cc66-b00e-4d9e-9e07-8cc3fb8ba674" />
<img width="669" height="375" alt="image" src="https://github.com/user-attachments/assets/3dd03cb2-ba92-42f1-864c-d6403752d203" />


## Changes
- [x]  Adjust base year CO2 limit after fixing `atmosphere` typo