### PR TITLE
review h2_export value and discountrate for wildcard

### DIFF
--- a/configs/config.main.yaml
+++ b/configs/config.main.yaml
@@ -16,6 +16,7 @@ retrieve_from_gdrive:
   renewable_profiles: true # if true, bypasses build_renewable_profiles rule
 
 costs:
+  discountrate: [0.07] # from the `fill_values` section
   output_currency: "USD"
   default_USD_to_EUR: 0.7532 # previously USD2013_to_EUR2013; should be sufficient as current data from `technology-data` are either in EUR or USD; [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
   year: 2030
@@ -39,6 +40,9 @@ costs:
     CCGT: 45
     OCGT: 45
 
+export:
+  endogenous: false # If true, the export demand is endogenously determined by the model
+  h2export: [0] # Yearly export demand in TWh. Only considered, if ["export"]["endogenous"] is set to false
 
 # defining the aviation demand scenario
 aviation_demand_scenario:

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,8 @@
 
 Please list contributions, add reference to PRs if present.
 
+* Set `h2_export` value to 0 and change `discountrate` for sector model wildcard to 0.07 in agreement with the values from `fill_values` [PR #110](https://github.com/open-energy-transition/efuels-supply-potentials/pull/110)
+
 * Apply **pre-OB3 tax credits** for solar, wind, electrolyzers, point-source CO2 and DAC for selected scenarios; extend credit to all battery components [PR #99](https://github.com/open-energy-transition/efuels-supply-potentials/pull/99)
 
 * Remove electrolyzers tax credits from config files, adapt **levelized tax credits** to global and technology-specific discount rates [PR #104](https://github.com/open-energy-transition/efuels-supply-potentials/pull/104)


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR reviews the `h2_export` value to 0 and sets `discountrate` for the wildcard of the sector model networks to 0.07 as from `fill_values`.

## Changes
- [x] Set `h2_export` to 0
- [x] Set `discountrate` to 0.07